### PR TITLE
Fix: Changed paths to devices

### DIFF
--- a/openrgb.xml
+++ b/openrgb.xml
@@ -24,8 +24,8 @@ As of now, only Gigabyte RGB Fusion 2.0 boards have been reported to have issues
   <Config Name="Web Port" Target="5800" Default="5800" Mode="tcp" Description="Container Port: 5800" Type="Port" Display="always" Required="true" Mask="false">5800</Config>
   <Config Name="VNC Port" Target="5900" Default="5900" Mode="tcp" Description="Container Port: 5900" Type="Port" Display="always" Required="false" Mask="false">5900</Config>
   <Config Name="AppData" Target="/config/" Default="/mnt/user/appdata/P3R-OpenRGB/" Mode="rw" Description="Container Path: /config/" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/P3R-OpenRGB/</Config>
-  <Config Name="SYS I2C" Target="/sys/bus/i2c/devices/" Default="" Mode="ro" Description="Container Path: /sys/bus/i2c/devices/" Type="Path" Display="always" Required="false" Mask="false">/sys/bus/i2c/devices/</Config>
-  <Config Name="DEV I2C" Target="/dev/i2c-0" Default="" Mode="ro" Description="Container Path: /dev/i2c-0" Type="Path" Display="always" Required="false" Mask="false">/dev/i2c-0</Config>
+  <Config Name="SYS I2C" Target="" Default="" Mode="" Description="" Type="Device" Display="always" Required="true" Mask="false">/sys/bus/i2c/devices</Config>
+  <Config Name="DEV I2C" Target="" Default="" Mode="" Description="" Type="Device" Display="always" Required="true" Mask="false">/dev/i2c-0</Config>
   <Config Name="VNC Password" Target="VNC_PASSWORD" Default="" Mode="" Description="Set New VNC Password" Type="Variable" Display="advanced-hide" Required="false" Mask="false"></Config>
   <Config Name="Default Profile" Target="DEFAULT_PROFILE" Default="default.orp" Mode="" Description="Set Default Profile" Type="Variable" Display="advanced-hide" Required="false" Mask="false"></Config>
   <Config Name="SDK Server Port" Target="6742" Default="6742" Mode="tcp" Description="Container Port: 6742" Type="Port" Display="advanced-hide" Required="false" Mask="false">6742</Config>


### PR DESCRIPTION
Fix: Some devices won't work properly in a Docker container when passed over as a path instead of a device.